### PR TITLE
Double to str conversion fix

### DIFF
--- a/AdysTech.InfluxDB.Client.Net/AdysTech.InfluxDB.Client.Net.csproj
+++ b/AdysTech.InfluxDB.Client.Net/AdysTech.InfluxDB.Client.Net.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>AdysTech.InfluxDB.Client.Net</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/AdysTech.InfluxDB.Client.Net/InfluxDBClient.cs
+++ b/AdysTech.InfluxDB.Client.Net/InfluxDBClient.cs
@@ -254,7 +254,7 @@ namespace AdysTech.InfluxDB.Client.Net
                     new KeyValuePair<string, string>("precision", precisionLiterals[(int) precision])
                     }).ReadAsStringAsync ();
 
-            var content = String.Format ("{0},{1} {2}={3} {4}", measurement, tags, field, value, timestamp);
+            var content = String.Format (System.Globalization.CultureInfo.GetCultureInfo("en-US"), "{0},{1} {2}={3} {4}", measurement, tags, field, value, timestamp);
             ByteArrayContent requestContent = new ByteArrayContent (Encoding.UTF8.GetBytes (content));
             HttpResponseMessage response = await PostAsync (builder, requestContent);
 
@@ -295,7 +295,7 @@ namespace AdysTech.InfluxDB.Client.Net
             //    content.AppendFormat ("{0},{1} {2} {3}\n", measurement, tags, value, timestamp);
             ////remove last \n
             //content.Remove (content.Length - 1, 1);
-            var valuesTxt=String.Join (",", values.Select (v => String.Format ("{0}={1}", v.Key, v.Value)));
+            var valuesTxt=String.Join (",", values.Select (v => String.Format (System.Globalization.CultureInfo.GetCultureInfo("en-US"), "{0}={1}", v.Key, v.Value)));
             var content = String.Format ("{0},{1} {2} {3}", measurement, tags, valuesTxt, timestamp);
 
             ByteArrayContent requestContent = new ByteArrayContent (Encoding.UTF8.GetBytes (content.ToString ()));


### PR DESCRIPTION
Forced en-US locale when converting double to string to ensure that .
(dot) is used as delimiter. InfluxDB won't accept anything else than dot
regardless on current locale.