### PR TITLE
Added Partial Writes, and malformatted requests

### DIFF
--- a/AdysTech.InfluxDB.Client.Net.Test/AdysTech.InfluxDB.Client.Net.Test.csproj
+++ b/AdysTech.InfluxDB.Client.Net.Test/AdysTech.InfluxDB.Client.Net.Test.csproj
@@ -51,6 +51,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="DataGen.cs" />
     <Compile Include="InfluxDBClientTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/AdysTech.InfluxDB.Client.Net.Test/DataGen.cs
+++ b/AdysTech.InfluxDB.Client.Net.Test/DataGen.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InfluxDB.Client.Test
+{
+    static class DataGen
+    {
+        private static readonly Random random = new Random ();
+        private static readonly object syncLock = new object ();
+
+        public static int RandomNumber(int min, int max)
+        {
+            lock ( syncLock )
+            { // synchronize
+                return random.Next (min, max);
+            }
+        }
+
+        public static int RandomInt()
+        {
+            lock ( syncLock )
+            { // synchronize
+                return random.Next ();
+            }
+        }
+
+        public static int RandomInt(int Max)
+        {
+            lock ( syncLock )
+            { // synchronize
+                return random.Next (Max);
+            }
+        }
+
+        public static double RandomDouble()
+        {
+            lock ( syncLock )
+            { // synchronize
+                return random.NextDouble ();
+            }
+        }
+
+        public static string RandomString()
+        {
+            var chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 ,=/\\";
+            var stringChars = new StringBuilder (16, 16);
+
+            for ( int i = 0; i < stringChars.Length; i++ )
+            {
+                lock ( syncLock )
+                {
+                    stringChars.Append(chars[random.Next (chars.Length)]);
+                }
+            }
+            return stringChars.ToString (); ;
+        }
+
+        public static DateTime RandomDate(DateTime from, DateTime to)
+        {
+            lock ( syncLock )
+            {
+                return from.AddTicks ((long) ( random.NextDouble () * ( to.Ticks - from.Ticks ) ));
+            }
+        }
+    }
+}

--- a/AdysTech.InfluxDB.Client.Net.Test/InfluxDBClientTest.cs
+++ b/AdysTech.InfluxDB.Client.Net.Test/InfluxDBClientTest.cs
@@ -359,6 +359,30 @@ namespace InfluxDB.Client.Test
 
         [TestMethod]
         [ExpectedException (typeof (InfluxDBException))]
+        public async Task TestPostPointAsync_InvalidReq()
+        {
+            var client = new InfluxDBClient (influxUrl, dbUName, dbpwd);
+            var time = DateTime.Now;
+            var today = DateTime.Now.ToShortDateString ();
+            var now = DateTime.Now.ToShortTimeString ();
+
+            var valDouble = new InfluxDatapoint<double> ();
+            valDouble.UtcTimestamp = DateTime.UtcNow;
+            valDouble.Tags.Add ("TestDate", today);
+            valDouble.Tags.Add ("TestTime", now);
+            valDouble.Fields.Add ("Doublefield", DataGen.RandomDouble ());
+            valDouble.Fields.Add ("Doublefield2", Double.NaN);
+            valDouble.MeasurementName = measurementName;
+            valDouble.Precision = TimePrecision.Seconds;
+
+            var r = await client.PostPointAsync (dbName, valDouble);
+            Assert.IsTrue (r, "PostPointsAsync retunred false");
+
+        }
+
+
+        [TestMethod]
+        [ExpectedException (typeof (InfluxDBException))]
         public async Task TestPostPointsAsync_PartialWrite()
         {
             var client = new InfluxDBClient (influxUrl, dbUName, dbpwd);

--- a/AdysTech.InfluxDB.Client.Net/AdysTech.InfluxDB.Client.Net.csproj
+++ b/AdysTech.InfluxDB.Client.Net/AdysTech.InfluxDB.Client.Net.csproj
@@ -47,6 +47,7 @@
     <Compile Include="InfluxDatapoint.cs" />
     <Compile Include="InfluxDBClient.cs" />
     <Compile Include="DataContracts\InfluxJsonTypes.cs" />
+    <Compile Include="InfluxDBException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServiceUnavailableException.cs" />
   </ItemGroup>

--- a/AdysTech.InfluxDB.Client.Net/ExtensionMethods.cs
+++ b/AdysTech.InfluxDB.Client.Net/ExtensionMethods.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace AdysTech.InfluxDB.Client.Net
@@ -19,10 +20,57 @@ namespace AdysTech.InfluxDB.Client.Net
                 case TimePrecision.Minutes: return (long) t.TotalMinutes;
                 case TimePrecision.Seconds: return (long) t.TotalSeconds;
                 case TimePrecision.Milliseconds: return (long) t.TotalMilliseconds;
-                case TimePrecision.Microseconds: return (long) t.Ticks * ( TimeSpan.TicksPerMillisecond / 1000 );
+                case TimePrecision.Microseconds: return (long) t.Ticks / ( TimeSpan.TicksPerMillisecond * 1000 );
                 case TimePrecision.Nanoseconds: return (long) t.Ticks * 100; //1 tick = 100 nano sec
             }
             return 0;
         }
+    }
+
+    public static class RegExHelper
+    {
+        public static List<string> ToList(this MatchCollection matches)
+        {
+            return matches.Cast<Match> ()
+                // flatten to single list
+                .SelectMany (o =>
+                    // extract captured results
+                    o.Groups.Cast<Capture> ()
+                        // don't need the pattern
+                    .Skip (1)
+                    .Select (c => c.Value)).ToList ();
+        }
+    }
+
+    public static class StringHelper
+    {
+        public static string Unescape(this string txt)
+        {
+            if ( string.IsNullOrEmpty (txt) ) { return txt; }
+            StringBuilder retval = new StringBuilder (txt.Length);
+             for ( int ix = 0; ix < txt.Length; )
+            {
+                int jx = txt.IndexOf ('\\', ix);
+                if ( jx < 0 || jx == txt.Length - 1 ) jx = txt.Length;
+                retval.Append (txt, ix, jx - ix);
+                if ( jx >= txt.Length ) break;
+                switch ( txt[jx + 1] )
+                {
+                    case 'n': retval.Append ('\n'); break;  // Line feed
+                    case 'r': retval.Append ('\r'); break;  // Carriage return
+                    case 't': retval.Append ('\t'); break;  // Tab
+                    case ',': retval.Append (','); break;
+                    case '"': retval.Append ('"'); break;
+                    case '=': retval.Append ('='); break;
+                    case '\\': retval.Append ('\\'); break; // Don't escape
+                    default:                                 // Unrecognized, copy as-is
+                        retval.Append ('\\').Append (txt[jx + 1]); break;
+                }
+                ix = jx + 2;
+            }
+
+            return retval.ToString ();
+        }
+
     }
 }

--- a/AdysTech.InfluxDB.Client.Net/InfluxDBClient.cs
+++ b/AdysTech.InfluxDB.Client.Net/InfluxDBClient.cs
@@ -122,6 +122,38 @@ namespace AdysTech.InfluxDB.Client.Net
             if ( response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.BadGateway || ( response.StatusCode == HttpStatusCode.InternalServerError && response.ReasonPhrase == "INKApi Error" ) ) //502 Connection refused
                 throw new UnauthorizedAccessException ("InfluxDB needs authentication. Check uname, pwd parameters");
             //if(response.StatusCode==HttpStatusCode.NotFound)
+            else if ( response.StatusCode == HttpStatusCode.BadRequest )
+            {
+                var content = await response.Content.ReadAsStringAsync ();
+                //regex assumes error text from https://github.com/influxdata/influxdb/blob/master/models/points.go ParsePointsWithPrecision
+                //fmt.Sprintf("'%s': %v", string(block[start:len(block)])
+                List<string> parts; bool partialWrite;
+                if ( content.Contains ("partial write") )
+                {
+                    if ( content.Contains ("\\n") )
+                        parts = Regex.Matches (content.Substring (content.IndexOf ("partial write:\\n") + 16), @"([\P{Cc}].*?) '([\P{Cc}].*?)':([\P{Cc}].*?)\\n").ToList ();
+                    else
+                        parts = Regex.Matches (content.Substring (content.IndexOf ("partial write:\\n") + 16), @"([\P{Cc}].*?) '([\P{Cc}].*?)':([\P{Cc}].*?)").ToList ();
+                    partialWrite = true;
+                }
+                else
+                {
+                    parts = Regex.Matches (content, @"{\""error"":""([9\P{Cc}]+) '([\P{Cc}]+)':([a-zA-Z0-9 ]+)").ToList ();
+                    partialWrite = false;
+                }
+                string l;
+                if ( parts[1].Contains ("\\n") )
+                    l = parts[1].Substring (0, parts[1].IndexOf ("\\n")).Unescape ();
+                else
+                    l = parts[1].Unescape ();
+
+                var point = points.Where (p => p.ConvertToInfluxLineProtocol () == l).FirstOrDefault ();
+                if ( point != null )
+                    throw new InfluxDBException (partialWrite ? "Partial Write" : "Failed to Write", String.Format ("{0}: {1} due to {2}", partialWrite ? "Partial Write" : "Failed to Write", parts[0], parts[2]), point);
+                else
+                    throw new InfluxDBException (partialWrite ? "Partial Write" : "Failed to Write", String.Format ("{0}: {1} due to {2}", partialWrite ? "Partial Write" : "Failed to Write", parts[0], parts[2]), l);
+                return false;
+            }
             else if ( response.StatusCode == HttpStatusCode.NoContent )
                 return true;
             else

--- a/AdysTech.InfluxDB.Client.Net/InfluxDBException.cs
+++ b/AdysTech.InfluxDB.Client.Net/InfluxDBException.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdysTech.InfluxDB.Client.Net
+{
+    public class InfluxDBException : InvalidOperationException
+    {
+        public string Reason { get; private set; }
+        public IInfluxDatapoint FailedPoint { get; private set; }
+        public string FailedLine { get; private set; }
+        public InfluxDBException(string reason, string message)
+            : base (message)
+        {
+            Reason = reason;
+        }
+
+        public InfluxDBException(string reason, string message, IInfluxDatapoint point)
+            : this (reason, message)
+        {
+            FailedPoint = point;
+        }
+
+        public InfluxDBException(string reason, string message, string line)
+            : this (reason, message)
+        {
+            FailedLine = line;
+        }
+    }
+}

--- a/AdysTech.InfluxDB.Client.Net/InfluxDatapoint.cs
+++ b/AdysTech.InfluxDB.Client.Net/InfluxDatapoint.cs
@@ -73,7 +73,7 @@ namespace AdysTech.InfluxDB.Client.Net
                 Tags = new Dictionary<string, string> (tags);
                 return true;
             }
-            catch ( Exception)
+            catch ( Exception )
             {
                 Tags = new Dictionary<string, string> ();
                 return false;
@@ -94,7 +94,7 @@ namespace AdysTech.InfluxDB.Client.Net
                 Fields = new Dictionary<string, T> (fields);
                 return true;
             }
-            catch ( Exception)
+            catch ( Exception )
             {
                 Fields = new Dictionary<string, T> ();
                 return false;
@@ -149,6 +149,10 @@ namespace AdysTech.InfluxDB.Client.Net
                 val = val.Replace (" ", "\\ ");
             if ( escapeEqualSign && val.Contains ('=') )
                 val = val.Replace ("=", "\\=");
+            //edge case, which will trigger Unbalanced Quotes exception in InfluxDB
+            if ( val.EndsWith ("\\") )
+                val = val.Substring (0, val.Length - 1);
+
             return val;
         }
 

--- a/AdysTech.InfluxDB.Client.Net/InfluxDatapoint.cs
+++ b/AdysTech.InfluxDB.Client.Net/InfluxDatapoint.cs
@@ -135,7 +135,8 @@ namespace AdysTech.InfluxDB.Client.Net
                 ////double has to have a . as decimal seperator for Influx
                 fields = String.Join (",", Fields.Select (v => new StringBuilder ().AppendFormat ("{0}={1}", EscapeChars (v.Key), String.Format (System.Globalization.CultureInfo.GetCultureInfo ("en-US"), "{0}", v.Value))));
 
-            line.AppendFormat (" {0} {1}", fields, UtcTimestamp.ToEpoch (Precision));
+
+            line.AppendFormat (" {0} {1}", fields, UtcTimestamp != DateTime.MinValue ? UtcTimestamp.ToEpoch (Precision) : DateTime.UtcNow.ToEpoch (Precision));
 
             return line.ToString ();
         }

--- a/AdysTech.InfluxDB.Client.Net/InfluxDatapoint.cs
+++ b/AdysTech.InfluxDB.Client.Net/InfluxDatapoint.cs
@@ -60,6 +60,48 @@ namespace AdysTech.InfluxDB.Client.Net
         }
 
         /// <summary>
+        /// Initializes tags with a preexisitng dictionary
+        /// </summary>
+        /// <param name="tags">Dictionary of tag/value pairs</param>
+        /// <returns>True:Success, False:Failure</returns>
+        public bool InitializeTags(IDictionary<string, string> tags)
+        {
+            if ( Tags.Count > 0 )
+                throw new InvalidOperationException ("Tags can be initialized only when the collection is empty");
+            try
+            {
+                Tags = new Dictionary<string, string> (tags);
+                return true;
+            }
+            catch ( Exception)
+            {
+                Tags = new Dictionary<string, string> ();
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Initializes fields with a preexisting dictionary
+        /// </summary>
+        /// <param name="fields">Dictionary of Field/Value pairs</param>
+        /// <returns>True:Success, False:Failure</returns>
+        public bool InitializeFields(IDictionary<string, T> fields)
+        {
+            if ( Fields.Count > 0 )
+                throw new InvalidOperationException ("Fields can be initialized only when the collection is empty");
+            try
+            {
+                Fields = new Dictionary<string, T> (fields);
+                return true;
+            }
+            catch ( Exception)
+            {
+                Fields = new Dictionary<string, T> ();
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Returns the string representing the point in InfluxDB Line protocol
         /// </summary>
         /// <returns></returns>
@@ -68,6 +110,8 @@ namespace AdysTech.InfluxDB.Client.Net
         {
             if ( Fields.Count == 0 )
                 throw new InvalidOperationException ("InfluxDB needs atleast one field in a line");
+            if ( String.IsNullOrWhiteSpace (MeasurementName) )
+                throw new InvalidOperationException ("InfluxDB needs a measurement name to accept a point");
 
             var line = new StringBuilder ();
             line.AppendFormat ("{0}", MeasurementName);

--- a/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
+++ b/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.2.1.0")]
-[assembly: AssemblyFileVersion("0.2.1.0")]
+[assembly: AssemblyVersion("0.2.5.0")]
+[assembly: AssemblyFileVersion("0.2.5.0")]

--- a/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
+++ b/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("AdysTech")]
 [assembly: AssemblyProduct("AdysTech.InfluxDB.Client.Net")]
-[assembly: AssemblyCopyright("Copyright © AdysTech 2015")]
+[assembly: AssemblyCopyright("Copyright © AdysTech 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
InfluxDB returns Http 400 for bad requests. If the request has multiple points to write, then some of them might be processed before getting a mal-formatted line. 
e.g. of complete failure are string values, with unbalanced quotes. All requests after such a point are rejected. 
e.g. of partial write are points with Double.NaN, where all other good points are processed normally.

InfluxDB.Client.Net will now throw an InfluxDBException, with `Reason` set to partial write or Failed to Write, and `FailedPoint` set to first point creating the said failure.