### PR TITLE
Adjust error extraction regex.

### DIFF
--- a/AdysTech.InfluxDB.Client.Net.Test/InfluxDBClientTest.cs
+++ b/AdysTech.InfluxDB.Client.Net.Test/InfluxDBClientTest.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Dynamic;
-using System.Linq;
-using AdysTech.InfluxDB.Client.Net;
-using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text.RegularExpressions;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace AdysTech.InfluxDB.Client.Net.Tests
 {
@@ -429,6 +426,34 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
                             e.GetType(), e.Message);
                 return;
             }
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InfluxDBException))]
+        public async Task TestPostPointsAsyncFailure()
+        {
+            var client = new InfluxDBClient(influxUrl, dbUName, dbpwd);
+
+            var points = new List<IInfluxDatapoint>();
+
+            var firstPoint = new InfluxDatapoint<int>();
+            firstPoint.UtcTimestamp = DateTime.UtcNow;
+            firstPoint.Fields.Add("value", 1);
+            firstPoint.MeasurementName = "SameKeyDifferentType";
+            firstPoint.Precision = TimePrecision.Milliseconds;
+            points.Add(firstPoint);
+
+
+            var secondPoint = new InfluxDatapoint<double>();
+            secondPoint.UtcTimestamp = DateTime.UtcNow;
+            secondPoint.Fields.Add("value", 123.1234);
+            secondPoint.MeasurementName = "SameKeyDifferentType";
+            secondPoint.Precision = TimePrecision.Milliseconds;
+            points.Add(secondPoint);
+
+
+            var r = await client.PostPointsAsync("Development", points);
+            Assert.IsTrue(r, "PostPointsAsync returned false");
         }
 
         [TestMethod()]

--- a/AdysTech.InfluxDB.Client.Net.Test/InfluxDBClientTest.cs
+++ b/AdysTech.InfluxDB.Client.Net.Test/InfluxDBClientTest.cs
@@ -40,7 +40,7 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
                 s.Start();
                 var r = await client.GetInfluxDBNamesAsync();
                 s.Stop();
-                Debug.WriteLine( s.ElapsedMilliseconds);
+                Debug.WriteLine(s.ElapsedMilliseconds);
 
                 Assert.IsTrue(r != null && r.Count > 0, "GetInfluxDBNamesAsync retunred null or empty collection");
             }
@@ -131,7 +131,7 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
 
                 var client = new InfluxDBClient(influxUrl, dbUName, dbpwd);
                 var r = await client.QueryDBAsync(dbName, "show measurements");
-                Assert.IsTrue(r != null && r.Count>0, "QueryDBAsync retunred null or invalid data");
+                Assert.IsTrue(r != null && r.Count > 0, "QueryDBAsync retunred null or invalid data");
             }
             catch (Exception e)
             {
@@ -145,7 +145,7 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
         public async Task TestQueryMultiSeriesAsync()
         {
             var client = new InfluxDBClient(influxUrl, dbUName, dbpwd);
-            
+
             Stopwatch s = new Stopwatch();
             s.Start();
             var r = await client.QueryMultiSeriesAsync(dbName, "SHOW STATS");
@@ -430,7 +430,7 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
 
         [TestMethod]
         [ExpectedException(typeof(InfluxDBException))]
-        public async Task TestPostPointsAsyncFailure()
+        public async Task TestPostPointsAsyncDifferentTypeFailure()
         {
             var client = new InfluxDBClient(influxUrl, dbUName, dbpwd);
 
@@ -452,8 +452,7 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
             points.Add(secondPoint);
 
 
-            var r = await client.PostPointsAsync("Development", points);
-            Assert.IsTrue(r, "PostPointsAsync returned false");
+            var r = await client.PostPointsAsync(dbName, points);
         }
 
         [TestMethod()]
@@ -485,7 +484,7 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
             Assert.IsTrue(p.Saved, "CreateRetentionPolicyAsync failed");
         }
 
-     
+
     }
 
 }

--- a/AdysTech.InfluxDB.Client.Net.Test/Tests.orderedtest
+++ b/AdysTech.InfluxDB.Client.Net.Test/Tests.orderedtest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<OrderedTest name="tests" storage="e:\visual studio projects\console\influxdb.client.net\adystech.influxdb.client.net.test\tests.orderedtest" id="ae8a7c43-c134-4ca0-8c92-bb18e7ee9a52" continueAfterFailure="true" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+<OrderedTest name="tests" storage="c:\_personal\github\influxdb.client.net\adystech.influxdb.client.net.test\tests.orderedtest" id="ae8a7c43-c134-4ca0-8c92-bb18e7ee9a52" continueAfterFailure="true" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <TestLinks>
     <TestLink id="57d01cf9-83ef-a005-0f85-eb5792247c78" name="TestGetInfluxDBNamesAsync_ServiceUnavailable" storage="bin\debug\influxdb.client.test.dll" type="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestElement, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.ObjectModel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <TestLink id="532c19b5-ea6f-7493-b6d5-a1d2fa80cf18" name="TestCreateDatabaseAsync" storage="bin\debug\influxdb.client.test.dll" type="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestElement, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.ObjectModel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
@@ -18,5 +18,6 @@
     <TestLink id="0fcf513b-dd30-6a18-48ac-393796540954" name="TestQueryAsync" storage="bin\debug\influxdb.client.test.dll" type="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestElement, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.ObjectModel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <TestLink id="53cf4c7c-91be-9ef6-6a88-f63a16979ee9" name="TestQueryMultiSeriesAsync" storage="bin\debug\influxdb.client.test.dll" type="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestElement, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.ObjectModel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <TestLink id="6001049c-1b46-8498-b0d8-f808d2fe3833" name="TestPostPointsAsync_PartialWrite" storage="bin\debug\influxdb.client.test.dll" type="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestElement, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.ObjectModel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+    <TestLink id="11054fc4-d3d5-b4ec-5a6d-a504cf2b3f90" name="TestPostPointsAsyncDifferentTypeFailure" storage="bin\debug\influxdb.client.test.dll" type="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestElement, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.ObjectModel, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   </TestLinks>
 </OrderedTest>

--- a/AdysTech.InfluxDB.Client.Net/InfluxDBClient.cs
+++ b/AdysTech.InfluxDB.Client.Net/InfluxDBClient.cs
@@ -160,7 +160,7 @@ namespace AdysTech.InfluxDB.Client.Net
         {
             Regex multiLinePattern = new Regex (@"([\P{Cc}].*?) '([\P{Cc}].*?)':([\P{Cc}].*?)\\n", RegexOptions.Compiled, TimeSpan.FromSeconds (5));
             Regex oneLinePattern = new Regex(@"{\""error"":""([9\P{Cc}]+) '([\P{Cc}]+)':([a-zA-Z0-9 ]+)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
-            Regex errorLinePattern = new Regex(@"{\""error\"":""([\w\s]+): ([\w\s]+): ([\d\w\s\""\\,-]+)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+            Regex errorLinePattern = new Regex(@"{\""error\"":""([\w\s]+): ([\w\s]+) ([\d\w\s\""\\,-]+)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
             var line = new StringBuilder ();
             foreach (var point in points)
@@ -477,7 +477,7 @@ namespace AdysTech.InfluxDB.Client.Net
                     {
                         result = await PostPointsAsync (dbName, group.Key.Precision, group.Key.Name, points);
                     }
-                    catch (Exception)
+                    catch (Exception ex)
                     {
                         throw;
                     }

--- a/AdysTech.InfluxDB.Client.Net/InfluxDBClient.cs
+++ b/AdysTech.InfluxDB.Client.Net/InfluxDBClient.cs
@@ -7,12 +7,11 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Runtime.Serialization.Json;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using AdysTech.InfluxDB.Client.Net.DataContracts;
 using System.Web.Script.Serialization;
+using AdysTech.InfluxDB.Client.Net.DataContracts;
 
 namespace AdysTech.InfluxDB.Client.Net
 {
@@ -160,8 +159,8 @@ namespace AdysTech.InfluxDB.Client.Net
         private async Task<bool> PostPointsAsync (string dbName, TimePrecision precision, string retention, IEnumerable<IInfluxDatapoint> points)
         {
             Regex multiLinePattern = new Regex (@"([\P{Cc}].*?) '([\P{Cc}].*?)':([\P{Cc}].*?)\\n", RegexOptions.Compiled, TimeSpan.FromSeconds (5));
-            Regex oneLinePattern = new Regex (@"{\""error"":""([9\P{Cc}]+) '([\P{Cc}]+)':([a-zA-Z0-9 ]+)", RegexOptions.Compiled, TimeSpan.FromSeconds (5));
-            Regex errorLinePattern = new Regex (@"{\""error"":""([9\P{Cc}]+) '([\P{Cc}]+)':([a-zA-Z0-9 ]+)", RegexOptions.Compiled, TimeSpan.FromSeconds (5));
+            Regex oneLinePattern = new Regex(@"{\""error"":""([9\P{Cc}]+) '([\P{Cc}]+)':([a-zA-Z0-9 ]+)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+            Regex errorLinePattern = new Regex(@"{\""error\"":""([\w\s]+): ([\w\s]+): ([\d\w\s\""\\,-]+)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
 
             var line = new StringBuilder ();
             foreach (var point in points)


### PR DESCRIPTION
Attempts to fix Issue #14 and include unit test surrounding it.

 -Add test for conflicting value for same key
 -Modify regex extracting error information