### PR TITLE
Fix to allow InfluxUrls including a path (e.g. if database is behind reverse proxy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.7.2 [2/7/2019]
+
+### Release Notes
+Handle InfluxUrl with paths
+
+### Bugfixes
+
+- [#57](https://github.com/AdysTech/InfluxDB.Client.Net/issues/57): API does not support URLs including a path 
+
 ## v0.7.1 [1/5/2018]
 
 ### Release Notes

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -6,7 +6,7 @@
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
     <Authors>AdysTech;mvadu</Authors>
-    <Version>0.7.1.0</Version>
+    <Version>0.7.2.0</Version>
     <PackageId>AdysTech.InfluxDB.Client.Net.Core</PackageId>
     <Copyright>© AdysTech 2016-2019</Copyright>
     <PackageProjectUrl>https://github.com/AdysTech/InfluxDB.Client.Net</PackageProjectUrl>
@@ -25,8 +25,8 @@ It currently supports
 8.  Query for all Continuous Queries 
 9.  Create/Drop Continuous Queries 
 10. Chunking Support in queries</PackageReleaseNotes>
-    <AssemblyVersion>0.7.1.0</AssemblyVersion>
-    <FileVersion>0.7.1.0</FileVersion>
+    <AssemblyVersion>0.7.2.0</AssemblyVersion>
+    <FileVersion>0.7.2.0</FileVersion>
     <PackageTags>InfluxDB Influx TSDB TimeSeries InfluxData Chunking retention RetentionPolicy</PackageTags>
   </PropertyGroup>
 

--- a/src/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
+++ b/src/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.1.0")]
-[assembly: AssemblyFileVersion("0.7.1.0")]
+[assembly: AssemblyVersion("0.7.2.0")]
+[assembly: AssemblyFileVersion("0.7.2.0")]

--- a/src/DataStructures/InfluxDBClient.cs
+++ b/src/DataStructures/InfluxDBClient.cs
@@ -94,7 +94,7 @@ namespace AdysTech.InfluxDB.Client.Net
         {
             var querybaseUrl = new Uri(InfluxUrl);
             var builder = new UriBuilder(querybaseUrl);
-            builder.Path = "query";
+            builder.Path += "query";
             builder.Query = await new FormUrlEncodedContent(Query).ReadAsStringAsync();
             try
             {
@@ -125,7 +125,7 @@ namespace AdysTech.InfluxDB.Client.Net
         {
             var querybaseUrl = new Uri(InfluxUrl);
             var builder = new UriBuilder(querybaseUrl);
-            builder.Path = "write";
+            builder.Path += "write";
 
             builder.Query = await new FormUrlEncodedContent(EndPoint).ReadAsStringAsync();
             //if (requestContent.Headers.ContentType == null)
@@ -448,7 +448,7 @@ namespace AdysTech.InfluxDB.Client.Net
         {
             var querybaseUrl = new Uri(InfluxUrl);
             var builder = new UriBuilder(querybaseUrl);
-            builder.Path = "ping";
+            builder.Path += "ping";
             try
             {
                 HttpResponseMessage response = await _client.GetAsync(builder.Uri);


### PR DESCRIPTION
A small change that allows InfluxUrl to include a path - e.g. http://somehost/influxdb/
This is useful if the database is located behind a reverse proxy

Fixes #57 