### PR TITLE
Support more datatypes in InfluxValueField 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.8.0 [3/14/2019]
+
+### Release Notes
+Requires now .Net Standard 2.0 instead of 1.6. New Interface IInfluxValueField and extended support of basic types in InfluxValueField when `InfluxDbClient.PostPointsAsync`.
+
 ## v0.7.3 [3/14/2019]
 
 ### Release Notes

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 **Now supports .Net Core, run same .Net code in Windows and Linux**
 
 ####  Nuget
-1. .Net 4.5.1 > [AdysTech.InfluxDB.Client.Net](https://www.nuget.org/packages/AdysTech.InfluxDB.Client.Net)
-2. .Core 1.1 > [AdysTech.InfluxDB.Client.Net.Core](https://www.nuget.org/packages/AdysTech.InfluxDB.Client.Net.Core/)
+1. .Net Standard 2.0 > [AdysTech.InfluxDB.Client.Net.Core](https://www.nuget.org/packages/AdysTech.InfluxDB.Client.Net.Core/) _(this is the preferred version)_
+2. .Net 4.5.1 > [AdysTech.InfluxDB.Client.Net](https://www.nuget.org/packages/AdysTech.InfluxDB.Client.Net)
 
 
 # InfluxDB.Client.Net

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -6,7 +6,7 @@
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
     <Authors>AdysTech;mvadu</Authors>
-    <Version>0.7.3.0</Version>
+    <Version>0.8.0.0</Version>
     <PackageId>AdysTech.InfluxDB.Client.Net.Core</PackageId>
     <Copyright>© AdysTech 2016-2019</Copyright>
     <PackageProjectUrl>https://github.com/AdysTech/InfluxDB.Client.Net</PackageProjectUrl>
@@ -25,8 +25,8 @@ It currently supports
 8.  Query for all Continuous Queries 
 9.  Create/Drop Continuous Queries 
 10. Chunking Support in queries</PackageReleaseNotes>
-    <AssemblyVersion>0.7.3.0</AssemblyVersion>
-    <FileVersion>0.7.3.0</FileVersion>
+    <AssemblyVersion>0.8.0.0</AssemblyVersion>
+    <FileVersion>0.8.0.0</FileVersion>
     <PackageTags>InfluxDB Influx TSDB TimeSeries InfluxData Chunking retention RetentionPolicy</PackageTags>
   </PropertyGroup>
 

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -41,6 +41,7 @@ It currently supports
 	<Compile Include="..\DataStructures\InfluxRetentionPolicy.cs" Link="DataStructures\InfluxRetentionPolicy.cs" />
 	<Compile Include="..\DataStructures\InfluxSeries.cs" Link="DataStructures\InfluxSeries.cs" />
 	<Compile Include="..\DataStructures\InfluxValueField.cs" Link="DataStructures\InfluxValueField.cs" />
+    <Compile Include="..\DataStructures\IInfluxValueField.cs" Link="DataStructures\IInfluxValueField.cs" />
 	<Compile Include="..\DataStructures\ServiceUnavailableException.cs" Link="DataStructures\ServiceUnavailableException.cs" />
 	<Compile Include="..\Extensions\EpochHelper.cs" Link="Extensions\EpochHelper.cs" />
 	<Compile Include="..\Extensions\RegExHelper.cs" Link="Extensions\RegExHelper.cs" />

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
-    <Description>.Net client for InfluxDB. Supports all InfluxDB version from 0.9 onwards. Supports both .Net 4.5.1+ and .Net Core.</Description>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Description>.Net client for InfluxDB. Supports all InfluxDB version from 0.9 onwards. Supports both .Net 4.6.1+ and .Net Core 2.0+.</Description>
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
     <Authors>AdysTech;mvadu</Authors>
@@ -41,7 +41,7 @@ It currently supports
 	<Compile Include="..\DataStructures\InfluxRetentionPolicy.cs" Link="DataStructures\InfluxRetentionPolicy.cs" />
 	<Compile Include="..\DataStructures\InfluxSeries.cs" Link="DataStructures\InfluxSeries.cs" />
 	<Compile Include="..\DataStructures\InfluxValueField.cs" Link="DataStructures\InfluxValueField.cs" />
-    <Compile Include="..\DataStructures\IInfluxValueField.cs" Link="DataStructures\IInfluxValueField.cs" />
+  <Compile Include="..\DataStructures\IInfluxValueField.cs" Link="DataStructures\IInfluxValueField.cs" />
 	<Compile Include="..\DataStructures\ServiceUnavailableException.cs" Link="DataStructures\ServiceUnavailableException.cs" />
 	<Compile Include="..\Extensions\EpochHelper.cs" Link="Extensions\EpochHelper.cs" />
 	<Compile Include="..\Extensions\RegExHelper.cs" Link="Extensions\RegExHelper.cs" />

--- a/src/AdysTech.InfluxDB.Client.Net/AdysTech.InfluxDB.Client.Net.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net/AdysTech.InfluxDB.Client.Net.csproj
@@ -76,6 +76,9 @@
     <Compile Include="..\DataStructures\InfluxValueField.cs">
       <Link>DataStructures\InfluxValueField.cs</Link>
     </Compile>
+    <Compile Include="..\DataStructures\IInfluxValueField.cs">
+      <Link>DataStructures\IInfluxValueField.cs</Link>
+    </Compile>
     <Compile Include="..\DataStructures\ServiceUnavailableException.cs">
       <Link>DataStructures\ServiceUnavailableException.cs</Link>
     </Compile>

--- a/src/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
+++ b/src/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -32,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.7.3.0")]
-[assembly: AssemblyFileVersion("0.7.3.0")]
+[assembly: AssemblyVersion("0.8.0.0")]
+[assembly: AssemblyFileVersion("0.8.0.0")]

--- a/src/DataStructures/IInfluxValueField.cs
+++ b/src/DataStructures/IInfluxValueField.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace AdysTech.InfluxDB.Client.Net
+{
+    public interface IInfluxValueField : IComparable, IComparable<IInfluxValueField>
+    {
+        Type DataType { get; }
+
+        IComparable Value { get; }
+
+        string ToString();
+    }
+}

--- a/src/DataStructures/InfluxDBClient.cs
+++ b/src/DataStructures/InfluxDBClient.cs
@@ -198,9 +198,9 @@ namespace AdysTech.InfluxDB.Client.Net
                         else
                             l = parts[1].Unescape();
                     }
-                    catch (InfluxDBException e)
+                    catch (InfluxDBException)
                     {
-                        throw e;
+                        throw;
                     }
                     catch (Exception)
                     {

--- a/src/DataStructures/InfluxDatapoint.cs
+++ b/src/DataStructures/InfluxDatapoint.cs
@@ -56,12 +56,7 @@ namespace AdysTech.InfluxDB.Client.Net
                 itemType == typeof(int) ||
                 itemType == typeof(bool) ||
                 itemType == typeof(string) ||
-#if NETSTANDARD1_6
-                typeof(IInfluxValueField).GetTypeInfo().IsAssignableFrom(itemType.GetTypeInfo())
-#else
-                typeof(IInfluxValueField).IsAssignableFrom(itemType)
-#endif
-                )
+                typeof(IInfluxValueField).IsAssignableFrom(itemType))
             {
                 Tags = new Dictionary<string, string>();
                 Fields = new Dictionary<string, T>();
@@ -148,11 +143,7 @@ namespace AdysTech.InfluxDB.Client.Net
             else if (tType == typeof(double))
                 ////double has to have a . as decimal seperator for Influx
                 fields = String.Join(",", Fields.Select(v => new StringBuilder().AppendFormat("{0}={1}", v.Key.EscapeChars(comma: true, equalSign: true, space: true), String.Format(new CultureInfo("en-US"), "{0}", v.Value))));
-#if NETSTANDARD1_6
-            else if (typeof(IInfluxValueField).GetTypeInfo().IsAssignableFrom(tType.GetTypeInfo()))
-#else
             else if (typeof(IInfluxValueField).IsAssignableFrom(tType))
-#endif
                 fields = String.Join(",", Fields.Select(v => new StringBuilder().AppendFormat("{0}={1}", v.Key.EscapeChars(comma: true, equalSign: true, space: true), v.Value.ToString())));
             else
                 throw new ArgumentException(tType + " is not supported by this library at this point");

--- a/src/DataStructures/InfluxDatapoint.cs
+++ b/src/DataStructures/InfluxDatapoint.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace AdysTech.InfluxDB.Client.Net
@@ -55,7 +56,12 @@ namespace AdysTech.InfluxDB.Client.Net
                 itemType == typeof(int) ||
                 itemType == typeof(bool) ||
                 itemType == typeof(string) ||
-                itemType == typeof(InfluxValueField))
+#if NETSTANDARD1_6
+                typeof(IInfluxValueField).GetTypeInfo().IsAssignableFrom(itemType.GetTypeInfo())
+#else
+                typeof(IInfluxValueField).IsAssignableFrom(itemType)
+#endif
+                )
             {
                 Tags = new Dictionary<string, string>();
                 Fields = new Dictionary<string, T>();
@@ -142,7 +148,11 @@ namespace AdysTech.InfluxDB.Client.Net
             else if (tType == typeof(double))
                 ////double has to have a . as decimal seperator for Influx
                 fields = String.Join(",", Fields.Select(v => new StringBuilder().AppendFormat("{0}={1}", v.Key.EscapeChars(comma: true, equalSign: true, space: true), String.Format(new CultureInfo("en-US"), "{0}", v.Value))));
-            else if (tType == typeof(InfluxValueField))
+#if NETSTANDARD1_6
+            else if (typeof(IInfluxValueField).GetTypeInfo().IsAssignableFrom(tType.GetTypeInfo()))
+#else
+            else if (typeof(IInfluxValueField).IsAssignableFrom(tType))
+#endif
                 fields = String.Join(",", Fields.Select(v => new StringBuilder().AppendFormat("{0}={1}", v.Key.EscapeChars(comma: true, equalSign: true, space: true), v.Value.ToString())));
             else
                 throw new ArgumentException(tType + " is not supported by this library at this point");

--- a/tests/AdysTech.InfluxDB.Client.Net.Core.Test/AdysTech.InfluxDB.Client.Net.Core.Test.csproj
+++ b/tests/AdysTech.InfluxDB.Client.Net.Core.Test/AdysTech.InfluxDB.Client.Net.Core.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,10 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\AdysTech.InfluxDB.Client.Net.Core\AdysTech.InfluxDB.Client.Net.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
In my case i write data from a PLC to influxdb. This 32bit controller result the data in smaler size as regular used in .net. So i have extended the conversion form source types.

I also have added a interface for `InfluxValueField`, so it is a lot more confortable to implement own behavior based on special datatypes.

Give me some feedback if needed. I can also write some test if you like 😎