### PR TITLE
Fix #82: QueryMultiSeriesAsync should return "partial" 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,54 @@
+# ASP.NET Core
+# Build and test ASP.NET Core projects targeting .NET Core.
+# Add steps that run tests, create a NuGet package, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/dotnet-core
+
+# the build will trigger on any changes to the master branch
+trigger:
+- master
+
+# the build will run on a Microsoft hosted agent, using the lastest Windows VM Image
+pool:
+  vmImage: 'windows-latest'
+
+# these variables are available throughout the build file
+# just the build configuration is defined, in this case we are building Release packages
+variables:
+  buildConfiguration: 'Release'
+
+#The build has 3 seperate tasks run under 1 step
+steps:
+
+# The first task is the dotnet command build, pointing to our csproj file
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build'
+  inputs:
+    command: 'build'
+    arguments: '--configuration $(buildConfiguration)'
+    projects: 'src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj'
+
+# The second task is dotnet pack command again pointing to the csproj file
+# The nobuild means the project will not be compiled before running pack, because its already built in above step
+- task: DotNetCoreCLI@2
+  displayName: "dotnet pack"
+  inputs:
+    command: 'pack'
+    arguments: '--configuration $(buildConfiguration)'
+    packagesToPack: 'src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj'
+    nobuild: true
+    versioningScheme: 'off'
+
+# The last task is a nuget command, nuget push
+# This will push any .nupkg files to the 'TestFeed' artifact feed
+# allowPackageConflicts allows us to build the same version and not throw an error when trying to push
+# instead it just ingores the latest package unless the version changes
+- task: NuGetCommand@2
+  displayName: 'nuget push'
+  inputs:
+    command: 'push'
+    feedsToUse: 'select'
+    packagesToPush: '$(Build.ArtifactStagingDirectory)/**/*.nupkg;!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg'
+    nuGetFeedType: 'internal'
+    publishVstsFeed: 'herrenknecht-up'
+    versioningScheme: 'off'
+    allowPackageConflicts: true

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -6,7 +6,7 @@
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
     <Authors>AdysTech;mvadu;Herrenknecht AG</Authors>
-    <Version>0.9.0.1</Version>
+    <Version>0.9.0.2</Version>
     <PackageId>AdysTech.InfluxDB.Client.Net.Core.HK</PackageId>
     <Copyright>© AdysTech 2016-2019</Copyright>
     <PackageProjectUrl>https://github.com/AdysTech/InfluxDB.Client.Net</PackageProjectUrl>
@@ -45,6 +45,7 @@ It currently supports
 	<Compile Include="..\DataStructures\InfluxMeasurement.cs" Link="DataStructures\InfluxMeasurement.cs" />
 	<Compile Include="..\DataStructures\InfluxRetentionPolicy.cs" Link="DataStructures\InfluxRetentionPolicy.cs" />
 	<Compile Include="..\DataStructures\InfluxSeries.cs" Link="DataStructures\InfluxSeries.cs" />
+  <Compile Include="..\DataStructures\InfluxResult.cs" Link="DataStructures\InfluxResult.cs" />
 	<Compile Include="..\DataStructures\InfluxValueField.cs" Link="DataStructures\InfluxValueField.cs" />
   <Compile Include="..\DataStructures\IInfluxValueField.cs" Link="DataStructures\IInfluxValueField.cs" />
 	<Compile Include="..\DataStructures\ServiceUnavailableException.cs" Link="DataStructures\ServiceUnavailableException.cs" />

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -6,7 +6,7 @@
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
     <Authors>AdysTech;mvadu;Herrenknecht AG</Authors>
-    <Version>0.9.0.3</Version>
+    <Version>0.9.0.4</Version>
     <PackageId>AdysTech.InfluxDB.Client.Net.Core.HK</PackageId>
     <Copyright>© AdysTech 2016-2019</Copyright>
     <PackageProjectUrl>https://github.com/AdysTech/InfluxDB.Client.Net</PackageProjectUrl>

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -5,8 +5,8 @@
     <Description>Herrenknecht specific .Net client for InfluxDB. Supports all InfluxDB version from 0.9 onwards. Supports both .Net 4.6.1+ and .Net Core 2.0+.</Description>
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
-    <Authors>AdysTech;mvadu</Authors>
-    <Version>0.9.0.0</Version>
+    <Authors>AdysTech;mvadu;Herrenknecht AG</Authors>
+    <Version>0.9.0.1</Version>
     <PackageId>AdysTech.InfluxDB.Client.Net.Core.HK</PackageId>
     <Copyright>© AdysTech 2016-2019</Copyright>
     <PackageProjectUrl>https://github.com/AdysTech/InfluxDB.Client.Net</PackageProjectUrl>

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -6,7 +6,7 @@
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
     <Authors>AdysTech;mvadu;Herrenknecht AG</Authors>
-    <Version>0.9.0.2</Version>
+    <Version>0.9.0.3</Version>
     <PackageId>AdysTech.InfluxDB.Client.Net.Core.HK</PackageId>
     <Copyright>© AdysTech 2016-2019</Copyright>
     <PackageProjectUrl>https://github.com/AdysTech/InfluxDB.Client.Net</PackageProjectUrl>

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Description>.Net client for InfluxDB. Supports all InfluxDB version from 0.9 onwards. Supports both .Net 4.6.1+ and .Net Core 2.0+.</Description>
+    <Description>Herrenknecht specific .Net client for InfluxDB. Supports all InfluxDB version from 0.9 onwards. Supports both .Net 4.6.1+ and .Net Core 2.0+.</Description>
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
     <Authors>AdysTech;mvadu</Authors>
     <Version>0.9.0.0</Version>
-    <PackageId>AdysTech.InfluxDB.Client.Net.Core</PackageId>
+    <PackageId>AdysTech.InfluxDB.Client.Net.Core.HK</PackageId>
     <Copyright>© AdysTech 2016-2019</Copyright>
     <PackageProjectUrl>https://github.com/AdysTech/InfluxDB.Client.Net</PackageProjectUrl>
     <RepositoryUrl>https://github.com/AdysTech/InfluxDB.Client.Net</RepositoryUrl>

--- a/src/AdysTech.InfluxDB.Client.Net/AdysTech.InfluxDB.Client.Net.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net/AdysTech.InfluxDB.Client.Net.csproj
@@ -70,6 +70,9 @@
     <Compile Include="..\DataStructures\InfluxRetentionPolicy.cs">
       <Link>DataStructures\InfluxRetentionPolicy.cs</Link>
     </Compile>
+    <Compile Include="..\DataStructures\InfluxResult.cs">
+      <Link>DataStructures\InfluxResult.cs</Link>
+    </Compile>
     <Compile Include="..\DataStructures\InfluxSeries.cs">
       <Link>DataStructures\InfluxSeries.cs</Link>
     </Compile>

--- a/src/DataStructures/InfluxDBClient.cs
+++ b/src/DataStructures/InfluxDBClient.cs
@@ -132,13 +132,10 @@ namespace AdysTech.InfluxDB.Client.Net
 
             try
             {
-                var pairs = new List<KeyValuePair<string, string>>
-                {
-                    new KeyValuePair<string, string>("q", query)
-                };
+                var body = new StringContent($"q={WebUtility.UrlEncode(query)}", Encoding.UTF8, 
+                    "application/x-www-form-urlencoded");
 
-                var content = new FormUrlEncodedContent(pairs);
-                HttpResponseMessage response = await _client.PostAsync(builder.Uri, content);
+                HttpResponseMessage response = await _client.PostAsync(builder.Uri, body);
 
                 if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.BadGateway || (response.StatusCode == HttpStatusCode.InternalServerError && response.ReasonPhrase == "INKApi Error")) //502 Connection refused
                         throw new UnauthorizedAccessException("InfluxDB needs authentication. Check uname, pwd parameters");
@@ -667,7 +664,8 @@ namespace AdysTech.InfluxDB.Client.Net
 
                 return multiResult;
             }
-            return null;
+            throw new Exception($"InfluxDB returned status code {response.StatusCode}: " +
+                                $"{await response.Content.ReadAsStringAsync()}");
         }
 
         /// <summary>

--- a/src/DataStructures/InfluxResult.cs
+++ b/src/DataStructures/InfluxResult.cs
@@ -1,0 +1,20 @@
+namespace AdysTech.InfluxDB.Client.Net
+{
+    /// <summary>
+    /// Extend the results returned by Query end point of the InfluxDB engine with the informations of Partial
+    /// and StatementID.
+    /// </summary>
+    public class InfluxResult
+    {
+        public int StatementID { get; set; }
+
+        public IInfluxSeries InfluxSeries { get; set; }
+
+        /// <summary>
+        /// True if the influx query was answered with a partial response due to e.g. exceeding a configured
+        /// max-row-limit in the InfluxDB. As we don't know which series was truncated by InfluxDB, all series
+        /// of the response will be flagged with Partial=true.
+        /// </summary>
+        public bool Partial { get; set; }
+    }
+}

--- a/src/DataStructures/InfluxSeries.cs
+++ b/src/DataStructures/InfluxSeries.cs
@@ -40,5 +40,12 @@ namespace AdysTech.InfluxDB.Client.Net
         /// of the response will be flagged with Partial=true.
         /// </summary>
         public bool Partial { get; set; }
+
+        public InfluxSeries() { }
+
+        public InfluxSeries(IReadOnlyList<dynamic> entries)
+        {
+            Entries = entries;
+        }
     }
 }

--- a/src/DataStructures/InfluxSeries.cs
+++ b/src/DataStructures/InfluxSeries.cs
@@ -33,5 +33,12 @@ namespace AdysTech.InfluxDB.Client.Net
         /// The objects will have columns as Peoperties with their current values
         /// </summary>
         public IReadOnlyList<dynamic> Entries { get; internal set; }
+
+        /// <summary>
+        /// True if the influx query was answered with a partial response due to e.g. exceeding a configured
+        /// max-row-limit in the InfluxDB. As we don't know which series was truncated by InfluxDB, all series
+        /// of the response will be flagged with Partial=true.
+        /// </summary>
+        public bool Partial { get; set; }
     }
 }

--- a/src/Interfaces/IInfluxDBClient.cs
+++ b/src/Interfaces/IInfluxDBClient.cs
@@ -94,6 +94,16 @@ namespace AdysTech.InfluxDB.Client.Net
         /// <returns>List of InfluxSeries</returns>
         Task<List<IInfluxSeries>> QueryMultiSeriesAsync(string dbName, string measurementQuery, string retentionPolicy = null, TimePrecision precision = TimePrecision.Nanoseconds);
 
+        /// <summary>
+        /// Queries Influx DB and gets multiple time series data back. Ideal for fetching measurement values.
+        /// The return list is of InfluxResult, that contains multiple InfluxSeries and each element in there will have properties named after columns in series.
+        /// </summary>
+        /// <param name="dbName">Name of the database</param>
+        /// <param name="measurementQuery">Query text, Supports multi series results</param>
+        /// <param name="retentionPolicy">retention policy containing the measurement</param>
+        /// <param name="precision">epoch precision of the data set</param>
+        /// <returns>List of InfluxResult that contains multiple InfluxSeries.</returns>
+        Task<List<InfluxResult>> QueryMultiSeriesMultiResultAsync(string dbName, string measurementQuery, string retentionPolicy = null, TimePrecision precision = TimePrecision.Nanoseconds);
 
         /// <summary>
         /// Queries Influx DB and gets a time series data back. Ideal for fetching measurement values.

--- a/src/Interfaces/IInfluxSeries.cs
+++ b/src/Interfaces/IInfluxSeries.cs
@@ -27,5 +27,12 @@ namespace AdysTech.InfluxDB.Client.Net
         /// Dictionary of tags, and their respective values.
         /// </summary>
         IReadOnlyDictionary<string, string> Tags { get; }
+
+        /// <summary>
+        /// True if the influx query was answered with a partial response due to e.g. exceeding a configured
+        /// max-row-limit in the InfluxDB. As we don't know which series was truncated by InfluxDB, all series
+        /// of the response will be flagged with Partial=true.
+        /// </summary>
+        bool Partial { get; set; }
     }
 }

--- a/tests/InfluxDBClientTest.cs
+++ b/tests/InfluxDBClientTest.cs
@@ -130,7 +130,60 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
             Assert.IsTrue(r != null, "QueryMultiSeriesAsync retunred null or invalid data");
         }
 
+        [TestMethod, TestCategory("Query")]
+        public async Task TestQueryMultiSeriesMultiResultAsync()
+        {
+            var measurement = "QueryMultiSeriesMultiTest";
+            var client = new InfluxDBClient(influxUrl, dbUName, dbpwd);
+            await client.CreateDatabaseAsync(dbName);
+            await client.DropMeasurementAsync(new InfluxDatabase(dbName), new InfluxMeasurement(measurement));
+            var points = new List<IInfluxDatapoint>();
 
+            var today = DateTime.Now.ToShortDateString();
+            var now = DateTime.UtcNow;
+            var nowString = DateTime.Now.ToShortTimeString();
+
+            for (int i = 0; i < 1; i++)
+            {
+                var valMixed = new InfluxDatapoint<InfluxValueField>();
+                valMixed.Tags.Add("TestDate", today);
+                valMixed.Tags.Add("TestTime", nowString);
+                valMixed.UtcTimestamp = now + TimeSpan.FromMilliseconds(i * 100);
+                valMixed.Fields.Add("Open", new InfluxValueField(DataGen.RandomDouble()));
+                valMixed.Fields.Add("High", new InfluxValueField(DataGen.RandomInt()));
+                valMixed.Fields.Add("Low", new InfluxValueField(DataGen.RandomDouble()));
+                valMixed.Fields.Add("Close", new InfluxValueField(DataGen.RandomDouble()));
+                valMixed.Fields.Add("Volume", new InfluxValueField(DataGen.RandomDouble()));
+
+                valMixed.MeasurementName = measurement;
+                valMixed.Precision = TimePrecision.Nanoseconds;
+                points.Add(valMixed);
+            }
+
+            await client.PostPointsAsync(dbName, points, 10000);
+
+            Stopwatch s = new Stopwatch();
+            s.Start();
+            var r = await client.QueryMultiSeriesMultiResultAsync(dbName, $"SELECT \"Open\", \"High\" FROM {measurement} Limit 1; SELECT \"Low\" FROM {measurement} Limit 1;");
+
+            s.Stop();
+            Debug.WriteLine($"Elapsed{s.ElapsedMilliseconds}");
+            Assert.IsTrue(r != null, "QueryMultiSeriesAsync retunred null or invalid data");
+            var firstResult = new Dictionary<string, object>(r[0].InfluxSeries.Entries[0]);
+            var secondResult = new Dictionary<string, object>(r[1].InfluxSeries.Entries[0]);
+
+            var valueActual = Convert.ToDouble(firstResult["Open"].ToString().Replace('.', ','));
+            var valueExpected = Convert.ToDouble(((InfluxDatapoint<InfluxValueField>)points[0]).Fields["Open"].Value);
+            Assert.IsTrue(Math.Abs(valueExpected - valueActual) < 0.000001);
+            
+            valueActual = Convert.ToInt32(firstResult["High"].ToString().Replace('.', ','));
+            valueExpected = Convert.ToInt32(((InfluxDatapoint<InfluxValueField>)points[0]).Fields["High"].Value);
+            Assert.IsTrue(Math.Abs(valueExpected - valueActual) < 0.000001);
+
+            valueActual = Convert.ToDouble(secondResult["Low"].ToString().Replace('.', ','));
+            valueExpected = Convert.ToDouble(((InfluxDatapoint<InfluxValueField>)points[0]).Fields["Low"].Value);
+            Assert.IsTrue(Math.Abs(valueExpected - valueActual) < 0.000001);
+        }
 
         [TestMethod, TestCategory("Post")]
         public async Task TestPostPointsAsync()

--- a/tests/InfluxDBClientTest.cs
+++ b/tests/InfluxDBClientTest.cs
@@ -820,6 +820,57 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
             }
         }
 
+        /// <summary>
+        /// You need to configure your test InfluxDB with a max-row-limit of 100.000 for this test to succeed!
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod, TestCategory("Perf")]
+        public async Task TestPartialResponseBecauseOfMaxRowLimit()
+        {
+            try
+            {
+                var client = new InfluxDBClient(influxUrl, dbUName, dbpwd);
+
+                var points = new List<IInfluxDatapoint>();
+
+                var today = DateTime.Now.ToShortDateString();
+                var now = DateTime.UtcNow;
+                var nowString = DateTime.Now.ToShortTimeString();
+                var measurement = "Partialtest";
+
+                for (int i = 0; i < 200000; i++)
+                {
+                    var valMixed = new InfluxDatapoint<InfluxValueField>();
+                    valMixed.Tags.Add("TestDate", today);
+                    valMixed.Tags.Add("TestTime", nowString);
+                    valMixed.UtcTimestamp = now + TimeSpan.FromMilliseconds(i * 100);
+                    valMixed.Fields.Add("Open", new InfluxValueField(DataGen.RandomDouble()));
+                    valMixed.Fields.Add("High", new InfluxValueField(DataGen.RandomDouble()));
+                    valMixed.Fields.Add("Low", new InfluxValueField(DataGen.RandomDouble()));
+                    valMixed.Fields.Add("Close", new InfluxValueField(DataGen.RandomDouble()));
+                    valMixed.Fields.Add("Volume", new InfluxValueField(DataGen.RandomDouble()));
+
+                    valMixed.MeasurementName = measurement;
+                    valMixed.Precision = TimePrecision.Nanoseconds;
+                    points.Add(valMixed);
+                }
+
+                await client.PostPointsAsync(dbName, points, 10000);
+
+                var r = await client.QueryMultiSeriesAsync(dbName, "SELECT * FROM Partialtest");
+                Assert.IsTrue(r.All(s => s.Partial), "Not all influx series returned by the query contained the flag 'partial=true'");
+
+                r = await client.QueryMultiSeriesAsync(dbName, "SELECT * FROM Partialtest limit 50000");
+                Assert.IsTrue(!r.Any(s => s.Partial), "At least one of the influx series returned by the query contained the flag 'partial=true'");
+            }
+            catch (Exception e)
+            {
+
+                Assert.Fail($"Unexpected exception of type {e.GetType()} caught: {e.Message}");
+                return;
+            }
+        }
+
         [TestMethod, TestCategory("Drop")]
         public async Task TestDropDatabaseAsync()
         {


### PR DESCRIPTION
This pull request is an attempt to implement #82 
If InfluxDB is configured to have a "max-row-limit", then InfluxDB will return the flag "partial=true" to indicate that a response has been truncated due to the max-row-limit.

With this pull request, the "partial" flag is included in the IInfluxSeries and set according to the influx raw response.
A unit test that verifies the changes has been implemented, too. However, you need to have an InfluxDB system with max-row-limit set to 100.000 for this test to succeed.