### PR TITLE
Fix #82: QueryMultiSeriesAsync should return "partial"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## v0.11.0 [02/01/2020]
+
+### Release Notes
+Option to add a rentention policy with infinite duration - Thanks to @jasase 
+Handle truncated responses due to "max-row-limit", (flag "partial=true"). Thanks to @tbraun-hk 
+
+### Bugfixes
+
+- [#82](https://github.com/AdysTech/InfluxDB.Client.Net/issues/82): QueryMultiSeriesAsync should return "partial" if responses are truncated by InfluxDB
+- [#83](https://github.com/AdysTech/InfluxDB.Client.Net/issues/83): Create Infinite Retention Policy
+
+## v0.9.0 [10/12/2019]
+
+### Release Notes
+Add  MeasurementHierarchy to IInfluxDatabase, SeriesCount and PointsCount properties to IInfluxMeasurement
+Now calling `GetInfluxDBStructureAsync` populates the structure with retention policies, and also gives the unique series and point counts for each of the measurements
+Allow for deleting/dropping the Influx database by calling `DropDatabaseAsync`, allow delete entire measurement via	`DropMeasurementAsync` as well as specific data points with and where clause using `TestDeletePointsAsync`
+
+### Bugfixes
+
+- [#72](https://github.com/AdysTech/InfluxDB.Client.Net/issues/72): Performance improvements
+- [#69](https://github.com/AdysTech/InfluxDB.Client.Net/issues/69): easiest way to count the entries in the measurement
+- [#67](https://github.com/AdysTech/InfluxDB.Client.Net/issues/67): delete an existing database
+- [#41](https://github.com/AdysTech/InfluxDB.Client.Net/issues/41): DELETE FROM {Measurement} WHERE
+
 ## v0.9.0 [10/12/2019]
 
 ### Release Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Handle truncated responses due to "max-row-limit", (flag "partial=true"). Thanks
 ### Bugfixes
 
 - [#82](https://github.com/AdysTech/InfluxDB.Client.Net/issues/82): QueryMultiSeriesAsync should return "partial" if responses are truncated by InfluxDB
-- [#82](https://github.com/AdysTech/InfluxDB.Client.Net/issues/83): Create Infinite Retention Policy
+- [#83](https://github.com/AdysTech/InfluxDB.Client.Net/issues/83): Create Infinite Retention Policy
 
 ## v0.9.0 [10/12/2019]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,6 @@ after_test:
 - ps: Get-ChildItem -include "AdysTech.InfluxDB.Client.Net.Core*nupkg" | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 deploy:
 - provider: NuGet
-  server: https://www.nuget.org/packages/AdysTech.InfluxDB.Client.Net
   api_key:
     secure: nlBDuJJE7GoAtSvHKJDjdutExvlEQErL8Q9gFqmhURY4xUgFT946cs2mLeQ2Qezi
   on:

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -6,7 +6,7 @@
     <Product>AdysTech.InfluxDB.Client.Net</Product>
     <Company>AdysTech</Company>
     <Authors>AdysTech;mvadu</Authors>
-    <Version>0.9.0.0</Version>
+    <Version>0.11.1.0</Version>
     <PackageId>AdysTech.InfluxDB.Client.Net.Core</PackageId>
     <Copyright>© AdysTech 2016-2019</Copyright>
     <PackageProjectUrl>https://github.com/AdysTech/InfluxDB.Client.Net</PackageProjectUrl>

--- a/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
+++ b/src/AdysTech.InfluxDB.Client.Net.Core/AdysTech.InfluxDB.Client.Net.Core.csproj
@@ -29,8 +29,8 @@ It currently supports
 10. Chunking Support in queries
 11. Drop databases, measurements or points
 12. Get series count or points count for a measurement</PackageReleaseNotes>
-    <AssemblyVersion>0.9.0.0</AssemblyVersion>
-    <FileVersion>0.9.0.0</FileVersion>
+    <AssemblyVersion>0.11.1.0</AssemblyVersion>
+    <FileVersion>0.11.1.0</FileVersion>
     <PackageTags>InfluxDB Influx TSDB TimeSeries InfluxData Chunking retention RetentionPolicy</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>

--- a/src/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
+++ b/src/AdysTech.InfluxDB.Client.Net/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.9.0.0")]
-[assembly: AssemblyFileVersion("0.9.0.0")]
+[assembly: AssemblyVersion("0.11.1.0")]
+[assembly: AssemblyFileVersion("0.11.1.0")]

--- a/src/DataStructures/InfluxSeries.cs
+++ b/src/DataStructures/InfluxSeries.cs
@@ -33,5 +33,12 @@ namespace AdysTech.InfluxDB.Client.Net
         /// The objects will have columns as Peoperties with their current values
         /// </summary>
         public IReadOnlyList<dynamic> Entries { get; internal set; }
+
+        /// <summary>
+        /// True if the influx query was answered with a partial response due to e.g. exceeding a configured
+        /// max-row-limit in the InfluxDB. As we don't know which series was truncated by InfluxDB, all series
+        /// of the response will be flagged with Partial=true.
+        /// </summary>
+        public bool Partial { get; set; }
     }
 }

--- a/src/Interfaces/IInfluxSeries.cs
+++ b/src/Interfaces/IInfluxSeries.cs
@@ -27,5 +27,12 @@ namespace AdysTech.InfluxDB.Client.Net
         /// Dictionary of tags, and their respective values.
         /// </summary>
         IReadOnlyDictionary<string, string> Tags { get; }
+
+        /// <summary>
+        /// True if the influx query was answered with a partial response due to e.g. exceeding a configured
+        /// max-row-limit in the InfluxDB. As we don't know which series was truncated by InfluxDB, all series
+        /// of the response will be flagged with Partial=true.
+        /// </summary>
+        bool Partial { get; set; }
     }
 }

--- a/tests/InfluxDBClientTest.cs
+++ b/tests/InfluxDBClientTest.cs
@@ -855,7 +855,8 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
                     points.Add(valMixed);
                 }
 
-                await client.PostPointsAsync(dbName, points, 10000);
+                
+                Assert.IsTrue(await client.PostPointsAsync(dbName, points, 25000), "PostPointsAsync retunred false");
 
                 var r = await client.QueryMultiSeriesAsync(dbName, "SELECT * FROM Partialtest");
                 Assert.IsTrue(r.All(s => s.Partial), "Not all influx series returned by the query contained the flag 'partial=true'");

--- a/tests/InfluxDBClientTest.cs
+++ b/tests/InfluxDBClientTest.cs
@@ -820,6 +820,57 @@ namespace AdysTech.InfluxDB.Client.Net.Tests
             }
         }
 
+        /// <summary>
+        /// You need to configure your test InfluxDB with a max-row-limit of 100.000 for this test to succeed!
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod, TestCategory("Perf")]
+        public async Task TestPartialResponseBecauseOfMaxRowLimit()
+        {
+            try
+            {
+                var client = new InfluxDBClient(influxUrl, dbUName, dbpwd);
+
+                var points = new List<IInfluxDatapoint>();
+
+                var today = DateTime.Now.ToShortDateString();
+                var now = DateTime.UtcNow;
+                var nowString = DateTime.Now.ToShortTimeString();
+                var measurement = "Partialtest";
+
+                for (int i = 0; i < 200000; i++)
+                {
+                    var valMixed = new InfluxDatapoint<InfluxValueField>();
+                    valMixed.Tags.Add("TestDate", today);
+                    valMixed.Tags.Add("TestTime", nowString);
+                    valMixed.UtcTimestamp = now + TimeSpan.FromMilliseconds(i * 100);
+                    valMixed.Fields.Add("Open", new InfluxValueField(DataGen.RandomDouble()));
+                    valMixed.Fields.Add("High", new InfluxValueField(DataGen.RandomDouble()));
+                    valMixed.Fields.Add("Low", new InfluxValueField(DataGen.RandomDouble()));
+                    valMixed.Fields.Add("Close", new InfluxValueField(DataGen.RandomDouble()));
+                    valMixed.Fields.Add("Volume", new InfluxValueField(DataGen.RandomDouble()));
+
+                    valMixed.MeasurementName = measurement;
+                    valMixed.Precision = TimePrecision.Nanoseconds;
+                    points.Add(valMixed);
+                }
+
+                await client.PostPointsAsync(dbName, points, 10000);
+
+                var r = await client.QueryMultiSeriesAsync(dbName, "SELECT * FROM Partialtest");
+                Assert.IsTrue(r.All(s => s.Partial), "Not all influx series returned by the query contained the flag 'partial=true'");
+
+                r = await client.QueryMultiSeriesAsync(dbName, "SELECT * FROM Partialtest limit 50000");
+                Assert.IsTrue(!r.Any(s => s.Partial), "At least one of the influx series returned by the query contained the flag 'partial=true'");
+            }
+            catch (Exception e)
+            {
+
+                Assert.Fail($"Unexpected exception of type {e.GetType()} caught: {e.Message}");
+                return;
+            }
+        }
+
         [TestMethod, TestCategory("Drop")]
         public async Task TestDropDatabaseAsync()
         {


### PR DESCRIPTION
This pull request is another attempt to implement #82
If InfluxDB is configured to have a "max-row-limit", then InfluxDB will return the flag "partial=true" to indicate that a response has been truncated due to the max-row-limit.

With this pull request, the "partial" flag is included in the IInfluxSeries and set according to the influx raw response.
A unit test that verifies the changes has been implemented, too. However, you need to have an InfluxDB system with max-row-limit set to 100.000 for this test to succeed.